### PR TITLE
fix for nullref when getting logger from service

### DIFF
--- a/MMBot.Core/LoggerConfigurator.cs
+++ b/MMBot.Core/LoggerConfigurator.cs
@@ -80,6 +80,7 @@ namespace MMBot
 
         public ICommonLog GetLogger()
         {
+            if (_logger == null) LoadLogger();
             return _logger;
         }
 


### PR DESCRIPTION
Changes to logging cause a null ref exception when executing as a service.  This is because the console appender is ignored when running as a service and thus the logger is never initialized.
