### PR TITLE
Move run as service to an explicit parameter so that Azure Web Jobs work

### DIFF
--- a/mmbot/Options.cs
+++ b/mmbot/Options.cs
@@ -14,6 +14,9 @@ namespace mmbot
         [Option('v', "verbose", HelpText = "Display logging in verbose mode")]
         public bool Verbose { get; set; }
 
+        [Option('s', "runAsService", HelpText = "Runs mmbot as a Windows Service")]
+        public bool RunAsService { get; set; }
+
         [Option('n', "noconfig", HelpText = "Do not process the mmbot.ini config file if present.")]
         public bool SkipConfiguration { get; set; }
 

--- a/mmbot/Program.cs
+++ b/mmbot/Program.cs
@@ -19,9 +19,15 @@ namespace mmbot
 
         static void Main(string[] args)
         {
-            if (Environment.UserInteractive)
+            var options = new Options();
+            CommandLine.Parser.Default.ParseArguments(args, options);
+
+            if (options.RunAsService)
             {
-                var options = new Options();
+                ServiceBase.Run(new ServiceBase[] { new Service(options) });
+            }
+            else
+            {
                 CommandLine.Parser.Default.ParseArguments(args, options);
 
                 if (options.LastParserState != null && options.LastParserState.Errors.Any())
@@ -50,13 +56,6 @@ namespace mmbot
 
                 }
             }
-            else
-            {
-                var options = new Options();
-                CommandLine.Parser.Default.ParseArguments(args, options);
-                ServiceBase.Run(new ServiceBase[] { new Service(options) });
-            }            
-
         }
 
     }


### PR DESCRIPTION
Azure Web Jobs allow users to upload a zip file through the management portal and Azure will look for an exe, py, bat, cmd etc in this zip file and run it once, on schedule or (in mmbot's case) continuously.

http://www.hanselman.com/blog/IntroducingWindowsAzureWebJobs.aspx

This is a pretty cool feature that can be used in conjunction with the relay router to have mmbot hosted in azure with minimal fuss. Downloading scripts from the catalog etc seems to still work.

Unfortunately you can't specify command line arguments and the exe is run in a non-interactive context so we either force a bat/cmd file to be used for WebJobs or we make the "run as service" explicit via command line parameters. This pull request does that 2nd option. Will need to update docs etc if we choose to merge this.
