### PR TITLE
Compiled script help commands not persisted

### DIFF
--- a/MMBot.Core/Robot.cs
+++ b/MMBot.Core/Robot.cs
@@ -604,7 +604,7 @@ namespace MMBot
         {
             script.Register(this);
 
-            HelpCommands.AddRange(script.GetHelp());
+            AddHelp(script.GetHelp().ToArray());
         }
 
         private class EventEmitItem


### PR DESCRIPTION
Robot.RegisterScript(IMMBotScript script) was adding help commands to
HelpCommands, which is a dynamically generated List.

Now using Robot.AddHelp instead (which takes a string[] instead of an
IEnumerable, so calling ToArray() - could change IMMBotScript interface,
but that would break compiled scripts elsewhere).
