### PR TITLE
Post-IoC fix for AzureTableBrain

### DIFF
--- a/MMBot.AzureTableBrain/AzureTableBrain.cs
+++ b/MMBot.AzureTableBrain/AzureTableBrain.cs
@@ -7,7 +7,7 @@ using Newtonsoft.Json;
 
 namespace MMBot.AzureTableBrain
 {
-    public class AzureTableBrain : IBrain
+    public class AzureTableBrain : IBrain, IMustBeInitializedWithRobot
     {
         private Robot _robot;
         private CloudTable _table;


### PR DESCRIPTION
Added IMustBeInitializedWithRobot so that Initialize() gets called.
