### PR TITLE
Fix for RobotBuilder not using configured name

### DIFF
--- a/MMBot.Core/RobotBuilder.cs
+++ b/MMBot.Core/RobotBuilder.cs
@@ -1,12 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Text;
 using Autofac;
-using Autofac.Core;
-using Autofac.Core.Activators.Reflection;
 using MMBot.Brains;
 using MMBot.Router;
 using MMBot.Scripts;
@@ -23,13 +18,12 @@ namespace MMBot
         private bool _pluginProbe = true;
         private bool _scriptProbe = true;
         private string _workingDirectory;
-        private string _name = "mmbot";
+        private string _name;
         private IDictionary<string, string> _config = new Dictionary<string, string>();
         private readonly ContainerBuilder _containerBuilder;
         private IRobotPluginLocator _pluginLocator;
         private Type _scriptStoreType;
         private Type _scriptRunnerType;
-        
 
         protected RobotBuilder()
         {
@@ -66,6 +60,7 @@ namespace MMBot
             }
 
             var fileSystem = new FileSystem();
+
             if(!string.IsNullOrEmpty(_workingDirectory))
             {
                 fileSystem.CurrentDirectory = _workingDirectory;
@@ -89,7 +84,7 @@ namespace MMBot
             var adapters = _adapterTypes.Select(a => container.Resolve(a, new NamedParameter("adapterId", a.Name))).ToDictionary(a => a.GetType().Name, a => a as IAdapter);
 
             var robot = container.Resolve<Robot>(
-                new NamedParameter("name", _name), 
+                new NamedParameter("name", _name ?? _config.GetValueOrDefault("MMBOT_ROBOT_NAME") ?? "mmbot"), 
                 new NamedParameter("config", _config),
                 new NamedParameter("adapters", adapters));
 
@@ -97,8 +92,6 @@ namespace MMBot
 
             return robot;
         }
-
-        
 
         public RobotBuilder DisablePluginDiscovery()
         {

--- a/MMBot.Tests/RobotBuilderTests.cs
+++ b/MMBot.Tests/RobotBuilderTests.cs
@@ -1,4 +1,5 @@
-﻿using Common.Logging;
+﻿using System.Collections.Generic;
+using Common.Logging;
 using Xunit;
 
 namespace MMBot.Tests
@@ -12,6 +13,63 @@ namespace MMBot.Tests
             var robot = builder.Build();
             
             Assert.IsType<Robot>(robot);
+        }
+
+        [Fact]
+        public void WhenWithNameCalledBuildNamesNewRobotWithName()
+        {
+            string name = "my-shiny-robot";
+            
+            var builder = new RobotBuilder(new LoggerConfigurator(LogLevel.All))
+                .WithName(name);
+
+            var robot = builder.Build();
+
+            Assert.IsType<Robot>(robot);
+            Assert.Equal(name, robot.Name);
+        }
+
+        [Fact]
+        public void WhenNameInConfigurationBuildNamesNewRobotFromConfiguration()
+        {
+            string name = "my-shiny-robot";
+
+            var builder = new RobotBuilder(new LoggerConfigurator(LogLevel.All))
+                .WithConfiguration(new Dictionary<string, string>{{"MMBOT_ROBOT_NAME", name}});
+
+            var robot = builder.Build();
+
+            Assert.IsType<Robot>(robot);
+            Assert.Equal(name, robot.Name);
+        }
+
+        [Fact]
+        public void WhenNameInConfigurationAndWithNameCalledBuildNamesNewRobotWithName()
+        {
+            string withName = "my-shiny-robot";
+            string configuredName = "my-not-so-shint-robot";
+
+            var builder = new RobotBuilder(new LoggerConfigurator(LogLevel.All))
+                .WithName(withName)
+                .WithConfiguration(new Dictionary<string, string> {{"MMBOT_ROBOT_NAME", configuredName}});
+
+            var robot = builder.Build();
+
+            Assert.IsType<Robot>(robot);
+            Assert.Equal(withName, robot.Name);
+            Assert.NotEqual(configuredName, robot.Name);
+        }
+
+        [Fact]
+        public void WhenNameNotDefinedBuildNamesNewRobotWithDefaultName()
+        {
+            string name = "mmbot";
+
+            var builder = new RobotBuilder(new LoggerConfigurator(LogLevel.All));
+            var robot = builder.Build();
+
+            Assert.IsType<Robot>(robot);
+            Assert.Equal(name, robot.Name);
         }
     }
 }

--- a/mmbot/Initializer.cs
+++ b/mmbot/Initializer.cs
@@ -22,9 +22,12 @@ namespace mmbot
             var logConfig = CreateLogConfig(options);
             ConfigurePath(options, logConfig.GetLogger());
 
+            var builder = new RobotBuilder(logConfig).WithConfiguration(GetConfiguration(options));
 
-            var builder = new RobotBuilder(logConfig)
-                            .WithConfiguration(GetConfiguration(options));
+            if (!string.IsNullOrWhiteSpace(options.Name))
+            {
+                builder.WithName(options.Name);
+            }
 
             if (options.Test)
             {

--- a/mmbot/Options.cs
+++ b/mmbot/Options.cs
@@ -1,16 +1,14 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 using CommandLine;
 using CommandLine.Text;
-using MMBot;
 
 namespace mmbot
 {
     public class Options
     {
-        
+        [Option("name", HelpText = "Set robot name. Default is 'mmbot'.")]
+        public string Name { get; set; }
+
         [Option('v', "verbose", HelpText = "Display logging in verbose mode")]
         public bool Verbose { get; set; }
 
@@ -59,6 +57,5 @@ namespace mmbot
             return string.Concat(Initializer.IntroText, help);
 
         }
-
     }
 }


### PR DESCRIPTION
Fixes #102. Precedence is RobotBuilder.WithName(), MMBOT_ROBOT_NAME, and
"mmbot" as default.
