### PR TITLE
Implement the Reply and Emote commands on HipChat adapter

### DIFF
--- a/MMBot.Core/Response.cs
+++ b/MMBot.Core/Response.cs
@@ -96,9 +96,16 @@ namespace MMBot
             await _robot.Adapters[_envelope.User.AdapterId].Reply(_envelope, message);
         }
 
-        public Task Emote(params string[] message)
+        public async Task Emote(params string[] message)
         {
-            return TaskAsyncHelper.Empty;
+            var adapter = _robot.GetAdapter(_envelope.User.AdapterId);
+
+            if (adapter == null)
+            {
+                _robot.Logger.Warn(string.Format("Could not find adapter matching key '{0}'", _envelope.User.AdapterId));
+                return;
+            }
+            await _robot.Adapters[_envelope.User.AdapterId].Emote(_envelope, message);
         }
 
         public Task Topic(params string[] message)

--- a/MMBot.HipChat/HipChatAdapter.cs
+++ b/MMBot.HipChat/HipChatAdapter.cs
@@ -174,13 +174,26 @@ namespace MMBot.HipChat
 
         public override async Task Reply(Envelope envelope, params string[] messages)
         {
-            await base.Send(envelope, messages);
+            await base.Reply(envelope, messages);
 
             if (messages == null || !messages.Any()) return;
 
             foreach (var message in messages)
             {
                 var to = new Jid(envelope.User.Name);
+                _client.Send(new agsXMPP.protocol.client.Message(to, string.Equals(to.Server, _confhost) ? MessageType.groupchat : MessageType.chat, message));
+            }
+        }
+
+        public override async Task Emote(Envelope envelope, params string[] messages)
+        {
+            await base.Emote(envelope, messages);
+
+            if (messages == null || !messages.Any()) return;
+
+            foreach (var message in messages.Select(m => "/me " + m))
+            {
+                var to = new Jid(envelope.User.Room);
                 _client.Send(new agsXMPP.protocol.client.Message(to, string.Equals(to.Server, _confhost) ? MessageType.groupchat : MessageType.chat, message));
             }
         }


### PR DESCRIPTION
I set up the Reply and Emote commands to work on the HipChat adapter, and for the corresponding commands on the Response class to call out to the originating adapter.

I've tested this on live HipChat and it seems to function properly.  I mostly just copy pasted the code from the reply methods and modified them as needed, so there is a minor refactoring opportunity there, but I'm not entirely sure which way one would want to go with it.
