### PR TITLE
Fix for Broken HipChatAdapter.Reply method

### DIFF
--- a/MMBot.HipChat/HipChatAdapter.cs
+++ b/MMBot.HipChat/HipChatAdapter.cs
@@ -178,10 +178,10 @@ namespace MMBot.HipChat
 
             if (messages == null || !messages.Any()) return;
 
-            var userAddress = _roster.Where(kvp => kvp.Value == envelope.User.Name).Select(kvp => kvp.Key).First();
+            var userAddress = _roster.Where(kvp => kvp.Value == envelope.User.Name).Select(kvp => kvp.Key).First() + '@' + _host;
             foreach (var message in messages)
             {
-                var to = new Jid(userAddress + '@' + _host);
+                var to = new Jid(userAddress);
                 _client.Send(new agsXMPP.protocol.client.Message(to, string.Equals(to.Server, _confhost) ? MessageType.groupchat : MessageType.chat, message));
             }
         }


### PR DESCRIPTION
Honestly not sure how or even IF this worked before, but I've fixed it.
Apparently you need the fully qualified user@host to be passed into the
Jid constructor.

Since that's only available via the _roster dictionary which is keyed on the numeric ID, I have to do a list scan by user name to get the hipchat numericID.  Definitely open to a better way of doing this if anyone sees it.
