### PR TITLE
Akavache file locky me no wanty. Might fix #126

### DIFF
--- a/MMBot.Core/Brains/AkavacheBrain.cs
+++ b/MMBot.Core/Brains/AkavacheBrain.cs
@@ -45,7 +45,7 @@ namespace MMBot.Brains
 
             // Only Save values in a single synchronized thread :(
             _valueUpdates
-                .ObserveOn(new TaskPoolScheduler(new TaskFactory())) // Spin off a TPL thread if we need one
+                .ObserveOn(new TaskPoolScheduler(Task.Factory)) // Spin off a TPL thread if we need one
                 .Synchronize() // Queue requests behind executing subscriptions
                 .Subscribe(l => l.Item2(), 
                 () => _pendingOperations.OnCompleted());


### PR DESCRIPTION
Akavache is deprecating the file system provider in favour of the Sqlite implementation. Probably for good reason. However this would be a breaking change to mmbot if we switched.

I suspect there are very few concurrent Sets going on but this change will off-load Set operations onto a new thread if necessary and queues those saves behind each other. Drastic but if we want high performing key-value store then Redis, Azure or a custom brain implementation is the way to go.

Thoughts? (There may have been beer involved in this code)
