### PR TITLE
Fix for #137 double -init .ini file crash

### DIFF
--- a/mmbot/Initializer.cs
+++ b/mmbot/Initializer.cs
@@ -95,7 +95,15 @@ namespace mmbot
 
             if (File.Exists(Path.Combine(installationFolder, "mmbot.template.ini")))
             {
-                File.Copy(Path.Combine(installationFolder, "mmbot.template.ini"), Path.Combine(path, "mmbot.ini"));
+                if (File.Exists(Path.Combine(path, "mmbot.ini")))
+                {
+                    Console.WriteLine("mmbot.ini already exists in current directory.");
+                    Console.WriteLine();
+                }
+                else
+                {
+                    File.Copy(Path.Combine(installationFolder, "mmbot.template.ini"), Path.Combine(path, "mmbot.ini"));
+                }
             }
 
             Console.WriteLine("The current directory has been initialized");


### PR DESCRIPTION
Writes a message to the screen and continues.
