### PR TITLE
Added simple AzureTableBrain nuspec based on RedisBrain's nuspec

### DIFF
--- a/MMBot.AzureTableBrain/MMBot.AzureTableBrain.csproj
+++ b/MMBot.AzureTableBrain/MMBot.AzureTableBrain.csproj
@@ -85,6 +85,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+    <None Include="Properties\MMBot.AzureTableBrain.nuspec" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/MMBot.AzureTableBrain/Properties/MMBot.AzureTableBrain.nuspec
+++ b/MMBot.AzureTableBrain/Properties/MMBot.AzureTableBrain.nuspec
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+    <metadata>
+        <id>MMBot.AzureTableBrain</id>
+        <version>0.1.0</version>
+        <authors>Sam Wood</authors>
+        <owners>Peter Goodman</owners>
+        <licenseUrl>https://github.com/mmbot/mmbot/blob/master/LICENSE.md</licenseUrl>
+        <projectUrl>https://github.com/mmbot/mmbot/</projectUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>An Azure Table Storage 'Brain' implementation for mmbot, a C# port of Github's Hubot chat bot</description>
+        <releaseNotes>Initial pre-release version.</releaseNotes>
+        <copyright>Copyright 2013</copyright>
+        <tags>hubot mmbot chat robot bot azure table brain</tags>
+    </metadata>
+</package>


### PR DESCRIPTION
This should allow you to "nuget pack" and publish it to nuget.org like you did with http://www.nuget.org/packages/MMBot.RedisBrain/

Once it's on nuget.org, it'll make it easier to get started with mmbot with an Azure Table brain via:

```
nuget install MMBot.AzureTableBrain -o packages
```

I tested the "nuget pack" locally and it works great.

I didn't go ahead an publish it to nuget.org since @PeteGoo publishes most MMBot related ones, so he or the original author, Sam Wood ( @Spksh ), deserves the credit. Feel free to publish it if you decide to accept this PR.

Thanks for all your work on mmbot. We really enjoy using it!
