### PR TITLE
Remove AutoFac except for where ScriptCS needs it

### DIFF
--- a/MMBot.Core/Adapters/ConsoleAdapter.cs
+++ b/MMBot.Core/Adapters/ConsoleAdapter.cs
@@ -35,7 +35,7 @@ namespace MMBot.Adapters
             {
                 var message = Console.ReadLine();
 
-                if (message.Equals("exit", StringComparison.OrdinalIgnoreCase))
+                if (message != null && message.Equals("exit", StringComparison.OrdinalIgnoreCase))
                 {
                     Environment.Exit(0);
                 }

--- a/MMBot.Core/Robot.cs
+++ b/MMBot.Core/Robot.cs
@@ -17,7 +17,7 @@ using LogLevel = Common.Logging.LogLevel;
 
 namespace MMBot
 {
-    public class Robot : IScriptPackContext
+    public class Robot : IScriptPackContext, IDisposable
     {
         public readonly List<ScriptMetadata> ScriptData = new List<ScriptMetadata>();
         protected bool _isConfigured = false;
@@ -515,6 +515,9 @@ namespace MMBot
             }
         }
 
-
+        public void Dispose()
+        {
+            Shutdown().Wait();
+        }
     }
 }

--- a/MMBot.Router.Nancy/Bootstrapper.cs
+++ b/MMBot.Router.Nancy/Bootstrapper.cs
@@ -1,22 +1,268 @@
-﻿using Autofac;
-using Nancy.Bootstrappers.Autofac;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+using Nancy;
+using Nancy.Bootstrapper;
+using Nancy.Diagnostics;
+
+using TinyIoC;
 
 namespace MMBot.Router.Nancy
 {
-    public class Bootstrapper : AutofacNancyBootstrapper
+    
+
+    /// <summary>
+    /// TinyIoC bootstrapper - registers default route resolver and registers itself as
+    /// INancyModuleCatalog for resolving modules but behaviour can be overridden if required.
+    /// </summary>
+    public class Bootstrapper : NancyBootstrapperWithRequestContainerBase<TinyIoCContainer>
     {
         private readonly IRouter _router;
+        /// <summary>
+        /// Default assemblies that are ignored for autoregister
+        /// </summary>
+        public static IEnumerable<Func<Assembly, bool>> DefaultAutoRegisterIgnoredAssemblies = new Func<Assembly, bool>[]
+            {
+                asm => asm.FullName.StartsWith("Microsoft.", StringComparison.InvariantCulture),
+                asm => asm.FullName.StartsWith("System.", StringComparison.InvariantCulture),
+                asm => asm.FullName.StartsWith("System,", StringComparison.InvariantCulture),
+                asm => asm.FullName.StartsWith("CR_ExtUnitTest", StringComparison.InvariantCulture),
+                asm => asm.FullName.StartsWith("mscorlib,", StringComparison.InvariantCulture),
+                asm => asm.FullName.StartsWith("CR_VSTest", StringComparison.InvariantCulture),
+                asm => asm.FullName.StartsWith("DevExpress.CodeRush", StringComparison.InvariantCulture),
+                asm => asm.FullName.StartsWith("IronPython", StringComparison.InvariantCulture),
+                asm => asm.FullName.StartsWith("IronRuby", StringComparison.InvariantCulture),
+                asm => asm.FullName.StartsWith("xunit", StringComparison.InvariantCulture),
+                asm => asm.FullName.StartsWith("Nancy.Testing", StringComparison.InvariantCulture),
+                asm => asm.FullName.StartsWith("MonoDevelop.NUnit", StringComparison.InvariantCulture),
+                asm => asm.FullName.StartsWith("SMDiagnostics", StringComparison.InvariantCulture),
+                asm => asm.FullName.StartsWith("CppCodeProvider", StringComparison.InvariantCulture),
+                asm => asm.FullName.StartsWith("WebDev.WebHost40", StringComparison.InvariantCulture),
+            };
 
         public Bootstrapper(IRouter router)
         {
             _router = router;
         }
 
-        protected override void ConfigureApplicationContainer(ILifetimeScope container)
+        /// <summary>
+        /// Gets the assemblies to ignore when autoregistering the application container
+        /// Return true from the delegate to ignore that particular assembly, returning true
+        /// does not mean the assembly *will* be included, a false from another delegate will
+        /// take precedence.
+        /// </summary>
+        protected virtual IEnumerable<Func<Assembly, bool>> AutoRegisterIgnoredAssemblies
         {
-            var builder = new ContainerBuilder();
-            builder.RegisterInstance(_router);
-            builder.Update(container.ComponentRegistry);
+            get { return DefaultAutoRegisterIgnoredAssemblies; }
+        }
+
+        /// <summary>
+        /// Configures the container using AutoRegister followed by registration
+        /// of default INancyModuleCatalog and IRouteResolver.
+        /// </summary>
+        /// <param name="container">Container instance</param>
+        protected override void ConfigureApplicationContainer(TinyIoCContainer container)
+        {
+            AutoRegister(container, this.AutoRegisterIgnoredAssemblies);
+            container.Register(_router);
+        }
+
+        /// <summary>
+        /// Resolve INancyEngine
+        /// </summary>
+        /// <returns>INancyEngine implementation</returns>
+        protected override sealed INancyEngine GetEngineInternal()
+        {
+            return this.ApplicationContainer.Resolve<INancyEngine>();
+        }
+
+        /// <summary>
+        /// Create a default, unconfigured, container
+        /// </summary>
+        /// <returns>Container instance</returns>
+        protected override TinyIoCContainer GetApplicationContainer()
+        {
+            return new TinyIoCContainer();
+        }
+
+        /// <summary>
+        /// Register the bootstrapper's implemented types into the container.
+        /// This is necessary so a user can pass in a populated container but not have
+        /// to take the responsibility of registering things like INancyModuleCatalog manually.
+        /// </summary>
+        /// <param name="applicationContainer">Application container to register into</param>
+        protected override sealed void RegisterBootstrapperTypes(TinyIoCContainer applicationContainer)
+        {
+            applicationContainer.Register<INancyModuleCatalog>(this);
+        }
+
+        /// <summary>
+        /// Register the default implementations of internally used types into the container as singletons
+        /// </summary>
+        /// <param name="container">Container to register into</param>
+        /// <param name="typeRegistrations">Type registrations to register</param>
+        protected override sealed void RegisterTypes(TinyIoCContainer container, IEnumerable<TypeRegistration> typeRegistrations)
+        {
+            foreach (var typeRegistration in typeRegistrations)
+            {
+                switch (typeRegistration.Lifetime)
+                {
+                    case Lifetime.Transient:
+                        container.Register(typeRegistration.RegistrationType, typeRegistration.ImplementationType).AsMultiInstance();
+                        break;
+                    case Lifetime.Singleton:
+                        container.Register(typeRegistration.RegistrationType, typeRegistration.ImplementationType).AsSingleton();
+                        break;
+                    case Lifetime.PerRequest:
+                        throw new InvalidOperationException("Unable to directly register a per request lifetime.");
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Register the various collections into the container as singletons to later be resolved
+        /// by IEnumerable{Type} constructor dependencies.
+        /// </summary>
+        /// <param name="container">Container to register into</param>
+        /// <param name="collectionTypeRegistrationsn">Collection type registrations to register</param>
+        protected override sealed void RegisterCollectionTypes(TinyIoCContainer container, IEnumerable<CollectionTypeRegistration> collectionTypeRegistrationsn)
+        {
+            foreach (var collectionTypeRegistration in collectionTypeRegistrationsn)
+            {
+                switch (collectionTypeRegistration.Lifetime)
+                {
+                    case Lifetime.Transient:
+                        container.RegisterMultiple(collectionTypeRegistration.RegistrationType, collectionTypeRegistration.ImplementationTypes).AsMultiInstance();
+                        break;
+                    case Lifetime.Singleton:
+                        container.RegisterMultiple(collectionTypeRegistration.RegistrationType, collectionTypeRegistration.ImplementationTypes).AsSingleton();
+                        break;
+                    case Lifetime.PerRequest:
+                        throw new InvalidOperationException("Unable to directly register a per request lifetime.");
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Register the given module types into the container
+        /// </summary>
+        /// <param name="container">Container to register into</param>
+        /// <param name="moduleRegistrationTypes">NancyModule types</param>
+        protected override sealed void RegisterRequestContainerModules(TinyIoCContainer container, IEnumerable<ModuleRegistration> moduleRegistrationTypes)
+        {
+            foreach (var moduleRegistrationType in moduleRegistrationTypes)
+            {
+                container.Register(
+                    typeof(INancyModule),
+                    moduleRegistrationType.ModuleType,
+                    moduleRegistrationType.ModuleType.FullName).
+                    AsSingleton();
+            }
+        }
+
+        /// <summary>
+        /// Register the given instances into the container
+        /// </summary>
+        /// <param name="container">Container to register into</param>
+        /// <param name="instanceRegistrations">Instance registration types</param>
+        protected override void RegisterInstances(TinyIoCContainer container, IEnumerable<InstanceRegistration> instanceRegistrations)
+        {
+            foreach (var instanceRegistration in instanceRegistrations)
+            {
+                container.Register(
+                    instanceRegistration.RegistrationType,
+                    instanceRegistration.Implementation);
+            }
+        }
+
+        /// <summary>
+        /// Creates a per request child/nested container
+        /// </summary>
+        /// <returns>Request container instance</returns>
+        protected override sealed TinyIoCContainer CreateRequestContainer()
+        {
+            return this.ApplicationContainer.GetChildContainer();
+        }
+
+        /// <summary>
+        /// Gets the diagnostics for initialisation
+        /// </summary>
+        /// <returns>IDiagnostics implementation</returns>
+        protected override IDiagnostics GetDiagnostics()
+        {
+            return this.ApplicationContainer.Resolve<IDiagnostics>();
+        }
+
+        /// <summary>
+        /// Gets all registered startup tasks
+        /// </summary>
+        /// <returns>An <see cref="IEnumerable{T}"/> instance containing <see cref="IApplicationStartup"/> instances. </returns>
+        protected override IEnumerable<IApplicationStartup> GetApplicationStartupTasks()
+        {
+            return this.ApplicationContainer.ResolveAll<IApplicationStartup>(false);
+        }
+        
+        /// <summary>
+        /// Gets all registered request startup tasks
+        /// </summary>
+        /// <returns>An <see cref="IEnumerable{T}"/> instance containing <see cref="IRequestStartup"/> instances.</returns>
+        protected override IEnumerable<IRequestStartup> RegisterAndGetRequestStartupTasks(TinyIoCContainer container, Type[] requestStartupTypes)
+        {
+            container.RegisterMultiple(typeof(IRequestStartup), requestStartupTypes);
+
+            return container.ResolveAll<IRequestStartup>(false);
+        }
+
+        /// <summary>
+        /// Gets all registered application registration tasks
+        /// </summary>
+        /// <returns>An <see cref="IEnumerable{T}"/> instance containing <see cref="IRegistrations"/> instances.</returns>
+        protected override IEnumerable<IRegistrations> GetRegistrationTasks()
+        {
+            return this.ApplicationContainer.ResolveAll<IRegistrations>(false);
+        }
+
+        /// <summary>
+        /// Retrieve all module instances from the container
+        /// </summary>
+        /// <param name="container">Container to use</param>
+        /// <returns>Collection of NancyModule instances</returns>
+        protected override sealed IEnumerable<INancyModule> GetAllModules(TinyIoCContainer container)
+        {
+            var nancyModules = container.ResolveAll<INancyModule>(false);
+            return nancyModules;
+        }
+
+        /// <summary>
+        /// Retreive a specific module instance from the container
+        /// </summary>
+        /// <param name="container">Container to use</param>
+        /// <param name="moduleType">Type of the module</param>
+        /// <returns>NancyModule instance</returns>
+        protected override sealed INancyModule GetModule(TinyIoCContainer container, Type moduleType)
+        {
+            container.Register(typeof(INancyModule), moduleType);
+
+            return container.Resolve<INancyModule>();
+        }
+
+        /// <summary>
+        /// Executes auto registation with the given container.
+        /// </summary>
+        /// <param name="container">Container instance</param>
+        private static void AutoRegister(TinyIoCContainer container, IEnumerable<Func<Assembly, bool>> ignoredAssemblies)
+        {
+            var assembly = typeof(NancyEngine).Assembly;
+
+            container.AutoRegister(AppDomain.CurrentDomain.GetAssemblies().Where(a => !ignoredAssemblies.Any(ia => ia(a))), DuplicateImplementationActions.RegisterMultiple, t => t.Assembly != assembly);
         }
     }
 }

--- a/MMBot.Router.Nancy/MMBot.Router.Nancy.csproj
+++ b/MMBot.Router.Nancy/MMBot.Router.Nancy.csproj
@@ -51,10 +51,6 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac, Version=3.3.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Autofac.3.3.1\lib\net40\Autofac.dll</HintPath>
-    </Reference>
     <Reference Include="Common.Logging, Version=2.1.2.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Common.Logging.2.1.2\lib\net40\Common.Logging.dll</HintPath>
@@ -78,17 +74,13 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.Owin.Hosting.2.0.2\lib\net45\Microsoft.Owin.Hosting.dll</HintPath>
     </Reference>
-    <Reference Include="Nancy, Version=0.21.1.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Nancy, Version=0.23.2.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Nancy.0.21.1\lib\net40\Nancy.dll</HintPath>
+      <HintPath>..\packages\Nancy.0.23.2\lib\net40\Nancy.dll</HintPath>
     </Reference>
-    <Reference Include="Nancy.Bootstrappers.Autofac, Version=0.21.1.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Nancy.Owin, Version=0.23.2.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Nancy.Bootstrappers.Autofac.0.21.1\lib\net40\Nancy.Bootstrappers.Autofac.dll</HintPath>
-    </Reference>
-    <Reference Include="Nancy.Owin, Version=0.21.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Nancy.Owin.0.21.1\lib\net40\Nancy.Owin.dll</HintPath>
+      <HintPath>..\packages\Nancy.Owin.0.23.2\lib\net40\Nancy.Owin.dll</HintPath>
     </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/MMBot.Router.Nancy/NancyRouterModule.cs
+++ b/MMBot.Router.Nancy/NancyRouterModule.cs
@@ -38,7 +38,7 @@ namespace MMBot.Router.Nancy
 
         private OwinContext CreateOwinContext()
         {
-            var owinContext = new OwinContext((IDictionary<string, object>)Context.Items[NancyOwinHost.RequestEnvironmentKey]);
+            var owinContext = new OwinContext(Context.GetOwinEnvironment());
             var parameters = Context.Parameters as DynamicDictionary;
             if (parameters != null)
             {

--- a/MMBot.Router.Nancy/packages.config
+++ b/MMBot.Router.Nancy/packages.config
@@ -1,15 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="3.3.1" targetFramework="net45" />
   <package id="Common.Logging" version="2.1.2" targetFramework="net45" />
   <package id="Common.Logging.Log4Net" version="2.0.1" targetFramework="net45" />
   <package id="log4net" version="1.2.10" targetFramework="net45" />
   <package id="Microsoft.Owin" version="2.0.2" targetFramework="net45" />
   <package id="Microsoft.Owin.Host.HttpListener" version="2.0.2" targetFramework="net45" />
   <package id="Microsoft.Owin.Hosting" version="2.0.2" targetFramework="net45" />
-  <package id="Nancy" version="0.21.1" targetFramework="net45" />
-  <package id="Nancy.Bootstrappers.Autofac" version="0.21.1" targetFramework="net45" />
-  <package id="Nancy.Owin" version="0.21.1" targetFramework="net45" />
+  <package id="Nancy" version="0.23.2" targetFramework="net45" />
+  <package id="Nancy.Owin" version="0.23.2" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
   <package id="Rx-Core" version="2.1.30214.0" targetFramework="net45" />
   <package id="Rx-Interfaces" version="2.1.30214.0" targetFramework="net45" />

--- a/MMBot.Tests/MMBot.Tests.csproj
+++ b/MMBot.Tests/MMBot.Tests.csproj
@@ -93,14 +93,13 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
     </Reference>
-    <Reference Include="Nancy">
-      <HintPath>..\packages\Nancy.0.21.1\lib\net40\Nancy.dll</HintPath>
+    <Reference Include="Nancy, Version=0.23.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Nancy.0.23.2\lib\net40\Nancy.dll</HintPath>
     </Reference>
-    <Reference Include="Nancy.Bootstrappers.Autofac">
-      <HintPath>..\packages\Nancy.Bootstrappers.Autofac.0.21.1\lib\net40\Nancy.Bootstrappers.Autofac.dll</HintPath>
-    </Reference>
-    <Reference Include="Nancy.Owin">
-      <HintPath>..\packages\Nancy.Owin.0.21.1\lib\net40\Nancy.Owin.dll</HintPath>
+    <Reference Include="Nancy.Owin, Version=0.23.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Nancy.Owin.0.23.2\lib\net40\Nancy.Owin.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.6.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/MMBot.Tests/RouterTests.cs
+++ b/MMBot.Tests/RouterTests.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Reactive;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
+using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -15,6 +16,9 @@ using MMBot.Router.Nancy;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Owin;
+
+using TinyIoC;
+
 using Xunit;
 using HttpStatusCode = System.Net.HttpStatusCode;
 
@@ -198,8 +202,10 @@ namespace MMBot.Tests
                         .DisableScriptDiscovery()
                         .Build();
 
+
             robot.AutoLoadScripts = false;
             
+            robot.Router.Start();
             setup(robot);
 
             await robot.Run();
@@ -232,8 +238,12 @@ namespace MMBot.Tests
                 set { _server = value; }
             }
 
-            public HttpClient Client {
-                get { return Server.HttpClient; }
+            public HttpClient Client 
+            {
+                get
+                {
+                    return Server.HttpClient;
+                }
             }
 
             public IObservable<Unit> Started
@@ -242,7 +252,7 @@ namespace MMBot.Tests
             }
 
             public override void Start()
-            {
+            {               
                 Server = TestServer.Create(app => app.UseNancy(options => options.Bootstrapper = new Bootstrapper(this)));
                 IsStarted = true;
 
@@ -252,7 +262,10 @@ namespace MMBot.Tests
 
             public void Dispose()
             {
-                Server.Dispose();
+                if (Server != null)
+                {
+                    Server.Dispose();
+                }
                 __robot.Shutdown().Wait();
             }
         }

--- a/MMBot.Tests/ScriptsTest.cs
+++ b/MMBot.Tests/ScriptsTest.cs
@@ -27,171 +27,194 @@ namespace MMBot.Tests
         [Fact]
         public async Task WhenPing_ReceivePong()
         {
-            var robot = new RobotBuilder(new LoggerConfigurator(LogLevel.All))
-                        .UseAdapter<StubAdapter>()
-                        .UseBrain<StubBrain>()
-                        .DisablePluginDiscovery()
-                        .DisableScriptDiscovery()
-                        .Build();
-            
-            robot.AutoLoadScripts = false;
-            var adapter = robot.Adapters.First().Value as StubAdapter;
-            robot.LoadScript<Ping>();
-            robot.AutoLoadScripts = false;
-            await robot.Run();
+            using (var robot = new RobotBuilder(new LoggerConfigurator(LogLevel.All))
+                .UseAdapter<StubAdapter>()
+                .UseBrain<StubBrain>()
+                .DisablePluginDiscovery()
+                .DisableScriptDiscovery()
+                .Build())
+            {
 
-            adapter.SimulateMessage("test1", "mmbot ping");
+                robot.AutoLoadScripts = false;
+                var adapter = robot.Adapters.First().Value as StubAdapter;
+                robot.LoadScript<Ping>();
+                robot.AutoLoadScripts = false;
+                await robot.Run();
 
-            var firstMessage = (await adapter.GetEmittedMessages(1)).Select(i => i.Item2).First();
-            Assert.Equal(1, firstMessage.Count());
-            Assert.Equal("pong", firstMessage.First(), StringComparer.InvariantCultureIgnoreCase);
+                adapter.SimulateMessage("test1", "mmbot ping");
+
+                var firstMessage = (await adapter.GetEmittedMessages(1)).Select(i => i.Item2).First();
+                Assert.Equal(1, firstMessage.Count());
+                Assert.Equal("pong", firstMessage.First(), StringComparer.InvariantCultureIgnoreCase);
+            }
         }
 
         [Fact]
         public async Task Auth_CanAddRemoveUsernameToRole()
         {
-            var robot = new RobotBuilder(new LoggerConfigurator(LogLevel.All))
-                        .UseAdapter<StubAdapter>()
-                        .UseBrain<StubBrain>()
-                        .DisablePluginDiscovery()
-                        .DisableScriptDiscovery()
-                        .Build();
-            var adapter = robot.Adapters.First().Value as StubAdapter;
-            robot.AutoLoadScripts = false;
-            robot.LoadScriptName("Auth");
-            await robot.Run();
+            using (var robot = new RobotBuilder(new LoggerConfigurator(LogLevel.All))
+                .UseAdapter<StubAdapter>()
+                .UseBrain<StubBrain>()
+                .DisablePluginDiscovery()
+                .DisableScriptDiscovery()
+                .Build())
+            {
+                var adapter = robot.Adapters.First().Value as StubAdapter;
+                robot.AutoLoadScripts = false;
+                robot.LoadScriptName("Auth");
+                await robot.Run();
 
-            Assert.True(robot.ScriptData.Any(d => d.Name == "Auth"));
+                Assert.True(robot.ScriptData.Any(d => d.Name == "Auth"));
 
-            adapter.SimulateMessage("test1", "mmbot add test1 to the testgroup role");
-            adapter.SimulateMessage("test1", "mmbot remove test1 from the testgroup role");
+                adapter.SimulateMessage("test1", "mmbot add test1 to the testgroup role");
+                adapter.SimulateMessage("test1", "mmbot remove test1 from the testgroup role");
 
-            var messages = await adapter.GetEmittedMessages(2);
-            Assert.Equal(2, messages.Count());
-            Assert.True(
-                "Got it, test1 is now in the testgroup role" == messages.First().Item2.First() ||
-                "test1 is already in the testgroup role" == messages.First().Item2.First());
-            Assert.Equal("Got it, test1 is no longer in the testgroup role", messages.Last().Item2.First(), StringComparer.InvariantCultureIgnoreCase);
+                var messages = await adapter.GetEmittedMessages(2);
+                Assert.Equal(2, messages.Count());
+                Assert.True(
+                    "Got it, test1 is now in the testgroup role" == messages.First().Item2.First() ||
+                    "test1 is already in the testgroup role" == messages.First().Item2.First());
+                Assert.Equal("Got it, test1 is no longer in the testgroup role", messages.Last().Item2.First(),
+                    StringComparer.InvariantCultureIgnoreCase);
+            }
         }
 
         [Fact]
         public async Task CanCatchAnyMessage()
         {
-            var robot = new RobotBuilder(new LoggerConfigurator(LogLevel.All))
-                        .UseAdapter<StubAdapter>()
-                        .UseBrain<StubBrain>()
-                        .DisablePluginDiscovery()
-                        .DisableScriptDiscovery()
-                        .Build();
+            using (var robot = new RobotBuilder(new LoggerConfigurator(LogLevel.All))
+                .UseAdapter<StubAdapter>()
+                .UseBrain<StubBrain>()
+                .DisablePluginDiscovery()
+                .DisableScriptDiscovery()
+                .Build())
+            {
 
-            var adapter = robot.Adapters.First().Value as StubAdapter;
-            robot.LoadScript<CatchAllTest>();
-            robot.AutoLoadScripts = false;
-            await robot.Run();
+                var adapter = robot.Adapters.First().Value as StubAdapter;
+                robot.LoadScript<CatchAllTest>();
+                robot.AutoLoadScripts = false;
+                await robot.Run();
 
-            adapter.SimulateMessage("tester", "test message");
+                adapter.SimulateMessage("tester", "test message");
 
-            var messages = await adapter.GetEmittedMessages(1);
-            Assert.Equal(1, messages.Count());
-            Assert.Equal("Caught msg test message from tester", messages.First().Item2.First(), StringComparer.InvariantCultureIgnoreCase);
+                var messages = await adapter.GetEmittedMessages(1);
+                Assert.Equal(1, messages.Count());
+                Assert.Equal("Caught msg test message from tester", messages.First().Item2.First(),
+                    StringComparer.InvariantCultureIgnoreCase);
 
-            adapter.SimulateEnter("tester");
+                adapter.SimulateEnter("tester");
 
-            messages = await adapter.GetEmittedMessages(2);
-            Assert.Equal(2, messages.Count());
-            Assert.Equal("Caught msg tester joined testRoom from tester", messages.Skip(1).First().Item2.First(), StringComparer.InvariantCultureIgnoreCase);
+                messages = await adapter.GetEmittedMessages(2);
+                Assert.Equal(2, messages.Count());
+                Assert.Equal("Caught msg tester joined testRoom from tester", messages.Skip(1).First().Item2.First(),
+                    StringComparer.InvariantCultureIgnoreCase);
 
-            adapter.SimulateLeave("tester");
+                adapter.SimulateLeave("tester");
 
-            messages = await adapter.GetEmittedMessages(3);
-            Assert.Equal(3, messages.Count());
-            Assert.Equal("Caught msg tester left testRoom from tester", messages.Skip(2).First().Item2.First(), StringComparer.InvariantCultureIgnoreCase);
+                messages = await adapter.GetEmittedMessages(3);
+                Assert.Equal(3, messages.Count());
+                Assert.Equal("Caught msg tester left testRoom from tester", messages.Skip(2).First().Item2.First(),
+                    StringComparer.InvariantCultureIgnoreCase);
 
-            adapter.SimulateTopic("tester", "new topic");
+                adapter.SimulateTopic("tester", "new topic");
 
-            messages = await adapter.GetEmittedMessages(4);
-            Assert.Equal(4, messages.Count());
-            Assert.Equal("Caught msg new topic from tester", messages.Skip(3).First().Item2.First(), StringComparer.InvariantCultureIgnoreCase);
+                messages = await adapter.GetEmittedMessages(4);
+                Assert.Equal(4, messages.Count());
+                Assert.Equal("Caught msg new topic from tester", messages.Skip(3).First().Item2.First(),
+                    StringComparer.InvariantCultureIgnoreCase);
+
+            }
+
         }
 
         [Fact]
         public async Task CanListen()
         {
-            var robot = new RobotBuilder(new LoggerConfigurator(LogLevel.All))
-            .UseAdapter<StubAdapter>()
-            .UseBrain<StubBrain>()
-            .WithName("mmbot")
-            .DisablePluginDiscovery()
-            .DisableScriptDiscovery()
-            .Build();
+            using (var robot = new RobotBuilder(new LoggerConfigurator(LogLevel.All))
+                .UseAdapter<StubAdapter>()
+                .UseBrain<StubBrain>()
+                .WithName("mmbot")
+                .DisablePluginDiscovery()
+                .DisableScriptDiscovery()
+                .Build())
+            {
 
-            var adapter = robot.Adapters.First().Value as StubAdapter;
-            robot.LoadScript<ListenerTest>();
-            robot.LoadScript<TextListenerTest>();
-            robot.AutoLoadScripts = false;
-            await robot.Run();
+                var adapter = robot.Adapters.First().Value as StubAdapter;
+                robot.LoadScript<ListenerTest>();
+                robot.LoadScript<TextListenerTest>();
+                robot.AutoLoadScripts = false;
+                await robot.Run();
 
-            Assert.IsType<Listener<TextMessage>>(robot.Listeners[0]);
-            Assert.IsType<Listener<TextMessage>>(robot.Listeners[1]);
-            Assert.IsType<Listener<TextMessage>>(robot.Listeners[2]);
-            Assert.IsType<TextListener>(robot.Listeners[3]);
+                Assert.IsType<Listener<TextMessage>>(robot.Listeners[0]);
+                Assert.IsType<Listener<TextMessage>>(robot.Listeners[1]);
+                Assert.IsType<Listener<TextMessage>>(robot.Listeners[2]);
+                Assert.IsType<TextListener>(robot.Listeners[3]);
 
-            adapter.SimulateMessage("tester", "test message");
+                adapter.SimulateMessage("tester", "test message");
 
-            var messages = await adapter.GetEmittedMessages(2);
-            Assert.Equal(2, messages.Count());
-            Assert.Equal("Handled TextMessage without regex", messages.First().Item2.First(), StringComparer.InvariantCultureIgnoreCase);
-            Assert.Equal("Handled TextMessage with no other handlers", messages.Skip(1).First().Item2.First(), StringComparer.InvariantCultureIgnoreCase);
+                var messages = await adapter.GetEmittedMessages(2);
+                Assert.Equal(2, messages.Count());
+                Assert.Equal("Handled TextMessage without regex", messages.First().Item2.First(),
+                    StringComparer.InvariantCultureIgnoreCase);
+                Assert.Equal("Handled TextMessage with no other handlers", messages.Skip(1).First().Item2.First(),
+                    StringComparer.InvariantCultureIgnoreCase);
 
-            adapter.SimulateMessage("tester", "testregex test message");
+                adapter.SimulateMessage("tester", "testregex test message");
 
-            messages = await adapter.GetEmittedMessages(5);
-            Assert.Equal(5, messages.Count());
-            Assert.Equal("Handled TextMessage with regex", messages.Skip(2).First().Item2.First(), StringComparer.InvariantCultureIgnoreCase);
-            Assert.Equal("Handled TextMessage without regex", messages.Skip(3).First().Item2.First(), StringComparer.InvariantCultureIgnoreCase);
-            Assert.Equal("Handled TextMessage with no other handlers", messages.Skip(4).First().Item2.First(), StringComparer.InvariantCultureIgnoreCase);
+                messages = await adapter.GetEmittedMessages(5);
+                Assert.Equal(5, messages.Count());
+                Assert.Equal("Handled TextMessage with regex", messages.Skip(2).First().Item2.First(),
+                    StringComparer.InvariantCultureIgnoreCase);
+                Assert.Equal("Handled TextMessage without regex", messages.Skip(3).First().Item2.First(),
+                    StringComparer.InvariantCultureIgnoreCase);
+                Assert.Equal("Handled TextMessage with no other handlers", messages.Skip(4).First().Item2.First(),
+                    StringComparer.InvariantCultureIgnoreCase);
 
-            adapter.SimulateMessage("tester", "mmbot gif me cat");
+                adapter.SimulateMessage("tester", "mmbot gif me cat");
 
-            messages = await adapter.GetEmittedMessages(7);
-            Assert.Equal(7, messages.Count());
-            Assert.Equal("Handled TextMessage without regex", messages.Skip(5).First().Item2.First(), StringComparer.InvariantCultureIgnoreCase);
-            Assert.Equal("cat", messages.Skip(6).First().Item2.First(), StringComparer.InvariantCultureIgnoreCase);
+                messages = await adapter.GetEmittedMessages(7);
+                Assert.Equal(7, messages.Count());
+                Assert.Equal("Handled TextMessage without regex", messages.Skip(5).First().Item2.First(),
+                    StringComparer.InvariantCultureIgnoreCase);
+                Assert.Equal("cat", messages.Skip(6).First().Item2.First(), StringComparer.InvariantCultureIgnoreCase);
+            }
         }
 
         [Fact]
         public async Task WhenScriptStringIsRun_ActionRespondsToMessage()
         {
-            var robot = new RobotBuilder(new LoggerConfigurator(LogLevel.All))
-            .UseAdapter<StubAdapter>()
-            .UseBrain<StubBrain>()
-            .DisablePluginDiscovery()
-            .DisableScriptDiscovery()
-            .Build();
+            using (var robot = new RobotBuilder(new LoggerConfigurator(LogLevel.All))
+                .UseAdapter<StubAdapter>()
+                .UseBrain<StubBrain>()
+                .DisablePluginDiscovery()
+                .DisableScriptDiscovery()
+                .Build())
+            {
 
-            var expectedFirst = "Bad";
-            var expectedSecond = "Good";
+                var expectedFirst = "Bad";
+                var expectedSecond = "Good";
 
-            robot.AutoLoadScripts = false;
-            var adapter = robot.Adapters.First().Value as StubAdapter;
-            var scriptPath = Path.GetFullPath(Path.Combine("ScriptFiles", "ScriptRespondBad.csx"));
-            robot.LoadScriptFile(scriptPath);
-            robot.AutoLoadScripts = false;
-            await robot.Run();
+                robot.AutoLoadScripts = false;
+                var adapter = robot.Adapters.First().Value as StubAdapter;
+                var scriptPath = Path.GetFullPath(Path.Combine("ScriptFiles", "ScriptRespondBad.csx"));
+                robot.LoadScriptFile(scriptPath);
+                robot.AutoLoadScripts = false;
+                await robot.Run();
 
-            adapter.SimulateMessage("test1", "mmbot test");
+                adapter.SimulateMessage("test1", "mmbot test");
 
-            var firstMessage = (await adapter.GetEmittedMessages(1)).Select(i => i.Item2).First();
-            Assert.Equal(1, firstMessage.Count());
-            Assert.Equal(expectedFirst, firstMessage.First(), StringComparer.InvariantCultureIgnoreCase);
+                var firstMessage = (await adapter.GetEmittedMessages(1)).Select(i => i.Item2).First();
+                Assert.Equal(1, firstMessage.Count());
+                Assert.Equal(expectedFirst, firstMessage.First(), StringComparer.InvariantCultureIgnoreCase);
 
-            robot.LoadScriptFile(Path.GetFullPath(Path.Combine("ScriptFiles", "ScriptRespondGood.csx")));
+                robot.LoadScriptFile(Path.GetFullPath(Path.Combine("ScriptFiles", "ScriptRespondGood.csx")));
 
-            adapter.SimulateMessage("test1", "mmbot test");
+                adapter.SimulateMessage("test1", "mmbot test");
 
-            var secondMessage = (await adapter.GetEmittedMessages(10)).Select(i => i.Item2).Last();
-            Assert.Equal(1, secondMessage.Count());
-            Assert.Equal(expectedSecond, secondMessage.First(), StringComparer.InvariantCultureIgnoreCase);
+                var secondMessage = (await adapter.GetEmittedMessages(10)).Select(i => i.Item2).Last();
+                Assert.Equal(1, secondMessage.Count());
+                Assert.Equal(expectedSecond, secondMessage.First(), StringComparer.InvariantCultureIgnoreCase);
+            }
         }
     }
 }

--- a/MMBot.Tests/packages.config
+++ b/MMBot.Tests/packages.config
@@ -11,9 +11,8 @@
   <package id="Microsoft.Owin.Hosting" version="2.0.2" targetFramework="net45" />
   <package id="Microsoft.Owin.Testing" version="2.0.2" targetFramework="net45" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
-  <package id="Nancy" version="0.21.1" targetFramework="net45" />
-  <package id="Nancy.Bootstrappers.Autofac" version="0.21.1" targetFramework="net45" />
-  <package id="Nancy.Owin" version="0.21.1" targetFramework="net45" />
+  <package id="Nancy" version="0.23.2" targetFramework="net45" />
+  <package id="Nancy.Owin" version="0.23.2" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.3" targetFramework="net45" />
   <package id="NuGet.Core" version="2.8.2" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />


### PR DESCRIPTION
Replaced the Bootstrapper of Nancy with TinyIoC/Copy-Paste of the Nancy
Default Bootstrapper.  Changed Robot to be Disposable like in the
UpgradeAutoFac branch, and made the same changes to the test
classes/console adapter.  50/50 tests pass.

Helps further #158 
