### PR TITLE
Service mode uses 100% cpu on 1 core.

### DIFF
--- a/MMBot.Core/Adapters/ConsoleAdapter.cs
+++ b/MMBot.Core/Adapters/ConsoleAdapter.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -19,19 +18,20 @@ namespace MMBot.Adapters
             _cancellationTokenSource = new CancellationTokenSource();
         }
 
-        public async override Task Run()
+        public override Task Run()
         {
             _listeningTask = Task.Factory.StartNew(() =>
             {
                 StartListening(_cancellationTokenSource.Token);
             }, _cancellationTokenSource.Token);
+            return Task.FromResult(0);
         }
 
-        private async Task StartListening(CancellationToken token)
+        private void StartListening(CancellationToken token)
         {
             _user = Robot.GetUser("ConsoleUser", "ConsoleUser", "Console", Id);
 
-            while (true)
+            while (!token.IsCancellationRequested)
             {
                 var message = Console.ReadLine();
 
@@ -40,11 +40,6 @@ namespace MMBot.Adapters
                     Environment.Exit(0);
                 }
                 Robot.Receive(new TextMessage(_user, message));
-
-                if (token.IsCancellationRequested)
-                {
-                    return;
-                }
             }
         }
 
@@ -60,8 +55,8 @@ namespace MMBot.Adapters
 
         public override async Task Close()
         {
-	        _cancellationTokenSource.Cancel();
-	        if (_listeningTask != null) await _listeningTask;
+            _cancellationTokenSource.Cancel();
+            if (_listeningTask != null) await _listeningTask;
         }
     }
 }


### PR DESCRIPTION
When I installed mmbot as a service it would always take up 100% cpu time on a single core.

Turns out this is because the `ConsoleAdapter` was being registered despite not being needed. The `Console.ReadLine()` was always returning null, so the adapter loop was running at full speed.
