### PR TITLE
Fixed help messages

### DIFF
--- a/MMBot.Core/Scripts/Auth.csx
+++ b/MMBot.Core/Scripts/Auth.csx
@@ -8,11 +8,11 @@
 * </configuration>
 *
 * <commands>
-*    mmbot give &lt;user&gt; the &lt;role&gt; role - assigns user to role
-*    mmbot remove &lt;user&gt; from the &lt;role&gt; - removes user from role;
-*    mmbot list roles for &lt;user&gt; - lists roles that the user has
-*    mmbot list admins - lists the admin users
-*    mmbot dump roles - dumps all user role assignments
+*    mmbot give (user) the (role) role - assigns user to role;
+*    mmbot remove (user) from the (role) - removes user from role;
+*    mmbot list roles for (user) - lists roles that the user has;
+*    mmbot list admins - lists the admin users;
+*    mmbot dump roles - dumps all user role assignments;
 * </commands>
 * 
 * <notes>

--- a/MMBot.Core/Scripts/Help.csx
+++ b/MMBot.Core/Scripts/Help.csx
@@ -5,9 +5,9 @@
 *
 * <commands>
 *     mmbot help - Displays all of the help commands that mmbot knows about.;
-*     mmbot help &lt;query&gt; - Displays all help commands that match &lt;query&gt;.;
+*     mmbot help (query) - Displays all help commands that match (query).;
 *     mmbot list scripts - Displays a list of all the loaded script files;
-*     mmbot man &lt;query&gt; - Displays the details for the script that matches &lt;query&gt;.;
+*     mmbot man (query) - Displays the details for the script that matches (query).;
 * </commands>
 * 
 * <author>

--- a/MMBot.Core/Scripts/Ping.csx
+++ b/MMBot.Core/Scripts/Ping.csx
@@ -13,8 +13,8 @@ robot.Respond(@"RESPAWN$", msg => {msg.Finish(); robot.Reset(); });
 robot.Hear(@"ROLL CALL$", msg => msg.Send(msg.Random(new[]{"I'm here", "present", "ready and waiting", "sup", robot.Name + " is alive", "yo", "I'm awake", "reporting in", "howdy"})));
 
 robot.AddHelp(
-    "mmbot ping -  Reply with pong",
-    "mmbot echo <text> - Reply back with <text>",
+    "mmbot ping - Reply with pong",
+    "mmbot echo (text) - Reply back with <text>",
     "mmbot time - Reply with current time",
     "mmbot die - End mmbot process"
 );

--- a/MMBot.Core/Scripts/Scheduler.csx
+++ b/MMBot.Core/Scripts/Scheduler.csx
@@ -8,10 +8,10 @@
 * </configuration>
 *
 * <commands>
-*     mmbot repeat every &lt;time&gt; &lt;command&gt;- Repeat an mmbot command on a schedule (e.g. 4m, 1s, 24h).;
-*     mmbot schedule for &lt;time> &lt;command&gt; - Schedule an mmbot command.;
+*     mmbot repeat every (time) (command)- Repeat an mmbot command on a schedule (e.g. 4m, 1s, 24h).;
+*     mmbot schedule for (time) (command) - Schedule an mmbot command.;
 *     mmbot list schedule- Lists all scheduled jobs.;
-*     mmbot stop job &lt;job|all&gt;- kills a scheduled job, all for all jobs.;
+*     mmbot stop job (job|all)- kills a scheduled job, all for all jobs.;
 * </commands>
 * 
 * <notes>


### PR DESCRIPTION
Some of the help messages were missing the semicolon separator.

Also made the bracketing consistent.
