### PR TITLE
Adding Cleanup Support To NuGet Upgrading

### DIFF
--- a/MMBot.Core/Robot.cs
+++ b/MMBot.Core/Robot.cs
@@ -19,6 +19,8 @@ namespace MMBot
 {
     public class Robot : IScriptPackContext, IDisposable
     {
+        public static string ResetEventName = "Resetting";
+
         public readonly List<ScriptMetadata> ScriptData = new List<ScriptMetadata>();
         protected bool _isConfigured = false;
         private readonly IDictionary<string, IAdapter> _adapters = new Dictionary<string, IAdapter>();
@@ -39,7 +41,10 @@ namespace MMBot
         protected virtual void OnResetRequested()
         {
             var handler = ResetRequested;
-            if (handler != null) handler(this, EventArgs.Empty);
+            if (handler != null)
+            {
+                handler(this, EventArgs.Empty);
+            }
         }
 
         public Robot(string name, IDictionary<string, string> config, LoggerConfigurator logConfig, IDictionary<string, IAdapter> adapters, IRouter router, IBrain brain, IScriptStore scriptStore, IScriptRunner scriptRunner)
@@ -388,7 +393,7 @@ namespace MMBot
 
         public async Task Reset()
         {
-            Emit("Resetting", true);
+            Emit(ResetEventName, true);
             try
             {
                 await Shutdown();


### PR DESCRIPTION
Adding support for the bot itself to store which packages in which directories to delete, and for the wrapper and executable itself to facilitate the deletion of those packages from disk once the bot's AppDomain no longer has a lock on the relevant files.

Tested on our internal mmbot scripts NuGet package, and w/ the HipChat adapter.  I also tested under the condition that the reset event gets invoked in some other manner, which would cause the brain to not contain the delete list.

I'm pretty certain the logic is solid.  The only thing I can think of that would break it is if a NuGet package does not use a monotonicly increasing versioning scheme, so even YYYYMMDD style versioning should work.  It looks like nothing the adapters or my packages are dependent on use anything but SemVer, and that is the standard anyway (NuGet core pretty heavily uses SemVer in it's implementation, with a fallback to other things).

This would resolve #170 and resolve #159.
