### PR TITLE
NuGet package dir cleanup using a raw text file

### DIFF
--- a/MMBot.Core/MMBot.Core.csproj
+++ b/MMBot.Core/MMBot.Core.csproj
@@ -177,6 +177,7 @@
     <Compile Include="MatchResult.cs" />
     <Compile Include="Message.cs" />
     <Compile Include="NuGetPackageAssemblyResolver.cs" />
+    <Compile Include="PackageDirCleaner.cs" />
     <Compile Include="Response.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Robot.cs" />

--- a/MMBot.Core/NuGetPackageAssemblyResolver.cs
+++ b/MMBot.Core/NuGetPackageAssemblyResolver.cs
@@ -8,7 +8,6 @@ using Common.Logging;
 using MMBot.Brains;
 using MMBot.Router;
 using MMBot.Scripts;
-using Roslyn.Compilers.CSharp;
 using ScriptCs;
 using ScriptCs.Hosting.Package;
 

--- a/MMBot.Core/PackageDirCleaner.cs
+++ b/MMBot.Core/PackageDirCleaner.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using ScriptCs;
+
+namespace MMBot
+{
+    public static class PackageDirCleaner
+    {
+
+        public static void CleanUpPackages()
+        {
+            if (!File.Exists(CleanUpFilePath))
+            {
+                return;
+            }
+
+            var dirsToDelete = File.ReadAllLines(CleanUpFilePath);
+
+            foreach (var dir in dirsToDelete.Where(Directory.Exists))
+            {
+                Directory.Delete(dir, true);
+            }
+
+            File.Delete(CleanUpFilePath);
+        }
+
+        public static void RegisterDirectoriesToDelete(IEnumerable<string> packageFoldersToDelete)
+        {
+            File.WriteAllLines(CleanUpFilePath, packageFoldersToDelete);
+        }
+
+        static string CleanUpFilePath
+        {
+            get
+            {
+                return Path.Combine(AppDomain.CurrentDomain.BaseDirectory,"packages-to-cleanup.txt");
+            }
+        }
+
+    }
+}

--- a/MMBot.Core/Scripts/NuGetScripts.cs
+++ b/MMBot.Core/Scripts/NuGetScripts.cs
@@ -13,14 +13,7 @@ namespace MMBot.Scripts
         private const string NuGetRepositoriesSetting = "MMBOT_NUGET_REPOS";
         private const string NuGetPackageAliasesSetting = "MMBOT_NUGET_PACKAGE_ALIASES";
         private const string NuGetResetAfterUpdateSetting = "MMBOT_NUGET_RESET";
-        public static string NugetFoldersToDeleteSetting
-        {
-            get
-            {
-                return "MMBOT_NUGET_DELETE_DIRECTORIES";
-            }
-        }
-
+       
         const string Add = "add|remember";
         const string Remove = "remove|delete|del|rem|forget";
         const string Package = "pkg|package";
@@ -243,13 +236,17 @@ namespace MMBot.Scripts
                 }
 
                 var packageFoldersToDelete = postInstallState.Except(latestVersions).Select(p => Path.Combine(path, p.Id + "." + p.Version)).ToList();
-                var setDeleteFolders = robot.Brain.Set(NugetFoldersToDeleteSetting, packageFoldersToDelete);
+
+                if (packageFoldersToDelete.Any())
+                {
+                    PackageDirCleaner.RegisterDirectoriesToDelete(packageFoldersToDelete);
+                    msg.Send("Old package versions to cleanup on next reset: ",string.Join(", ",packageFoldersToDelete));
+                }
 
                 if (ShouldAutoResetAfterUpdate(robot) || (msg.Match.Length >= 5 && Regex.IsMatch(msg.Match[4], Restart)))
                 {
                     //They submitted the reset parameter or auto-reset is on.
                     msg.Send("Resetting...please wait.");
-                    setDeleteFolders.Wait();
                     robot.Reset();
                 }
             });

--- a/mmbot/Program.cs
+++ b/mmbot/Program.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.ServiceProcess;
 using System.Threading;
 using MMBot;
-using MMBot.Scripts;
 
 namespace mmbot
 {
@@ -20,6 +18,10 @@ namespace mmbot
             {
                 return;
             }
+
+            //always cleanup if needed
+            PackageDirCleaner.CleanUpPackages();
+
 
             if (options.RunAsService)
             {
@@ -52,22 +54,19 @@ namespace mmbot
             var childAppDomain = AppDomain.CreateDomain(Guid.NewGuid().ToString("N"));
             var wrapper = childAppDomain.CreateInstanceAndUnwrap(typeof(RobotWrapper).Assembly.FullName,
                 typeof(RobotWrapper).FullName) as RobotWrapper;
-
+            
             wrapper.Start(options); //Blocks, waiting on a reset event.
 
-            //Select and ToList called to force re-instantiation of all strings and list itself inside of this outer AppDomain
-            //or we will get crazy exceptions related to disposing/unloading of the child AppDomain in which the bot itself runs
-            var dirsToDelete = wrapper.DirectoriesToDeleteOnReset.Select(s => s + string.Empty).ToList();
-                
             AppDomain.Unload(childAppDomain);
-            foreach (var dir in dirsToDelete.Where(Directory.Exists))
-            {
-                Directory.Delete(dir, true);
-            }
+
+            PackageDirCleaner.CleanUpPackages();
 
             SetupRobot(options);
         }
+
+
     }
+
 
     public class RobotWrapper : MarshalByRefObject
     {
@@ -77,13 +76,6 @@ namespace mmbot
         {
             get { return _options; }
         }
-
-        public RobotWrapper()
-        {
-            DirectoriesToDeleteOnReset = new List<string>();
-        }
-
-        public List<string> DirectoriesToDeleteOnReset { get; set; }
 
         public void Start(Options options)
         {
@@ -95,18 +87,6 @@ namespace mmbot
                 // Something went wrong. Abort
                 Environment.Exit(-1);
             }
-
-            robot.On<bool>(Robot.ResetEventName,
-                     (b) =>
-                         {
-                             var getDirsToDelete = robot.Brain.Get<List<string>>(NuGetScripts.NugetFoldersToDeleteSetting);
-                             getDirsToDelete.Wait();
-                             var result = getDirsToDelete.Result;
-                             if (result != null)
-                             {
-                                 DirectoriesToDeleteOnReset = result;
-                             }
-                         });
 
             var resetEvent = new AutoResetEvent(false);
             robot.ResetRequested += (sender, args) => resetEvent.Set();


### PR DESCRIPTION
This way we don't need a brain to cleanup and can do it on restarts.

@PeteGoo @jamesbascle what do U guys think?

It also seem that we don't support the reset when running as a windows service? (don't we need an appdomain there as well to support hot reloads without restarting the win service)
