### PR TITLE
Added rate limiter for the Slack API

### DIFF
--- a/MMBot.Slack/MMBot.Slack.csproj
+++ b/MMBot.Slack/MMBot.Slack.csproj
@@ -32,6 +32,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Bert.RateLimiters">
+      <HintPath>..\packages\Bert.RateLimiters.1.0.0\lib\net45\Bert.RateLimiters.dll</HintPath>
+    </Reference>
     <Reference Include="Common.Logging">
       <HintPath>..\packages\Common.Logging.2.1.2\lib\net40\Common.Logging.dll</HintPath>
     </Reference>
@@ -64,6 +67,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="PerSecondRateLimiter.cs" />
     <Compile Include="SlackAdapter.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SlackAPI.cs" />

--- a/MMBot.Slack/PerSecondRateLimiter.cs
+++ b/MMBot.Slack/PerSecondRateLimiter.cs
@@ -1,0 +1,28 @@
+﻿using System.Threading;
+using Bert.RateLimiters;
+
+namespace MMBot.Slack
+{
+    public class PerSecondRateLimiter
+    {
+        private readonly FixedTokenBucket bucket;
+
+        public PerSecondRateLimiter(int requestsPerSecond)
+        {
+            bucket = new FixedTokenBucket(1, 1, 1000 / requestsPerSecond);
+        }
+
+        public void Limit()
+        {
+            while (true)
+            {
+                if (!bucket.ShouldThrottle(1))
+                {
+                    break;
+                }
+
+                Thread.Sleep(100);
+            }
+        }
+    }
+}

--- a/MMBot.Slack/SlackAPI.cs
+++ b/MMBot.Slack/SlackAPI.cs
@@ -1,3 +1,5 @@
+using System.Runtime.InteropServices;
+using Bert.RateLimiters;
 using ServiceStack;
 using ServiceStack.Text;
 using WebSocket4Net;
@@ -6,6 +8,7 @@ namespace MMBot.Slack
 {
     public class SlackAPI
     {
+        private static PerSecondRateLimiter limiter = new PerSecondRateLimiter(1); 
         private const string rtm_start = "https://slack.com/api/rtm.start";
         private const string channels_join = "https://slack.com/api/channels.join";
         private const string im_open = "https://slack.com/api/im.open";
@@ -57,7 +60,7 @@ namespace MMBot.Slack
             using (GetJsConfigScope())
             {
                 var data = StringExtensions.ToJson(new SendMessage(channel, message, replyId));
-
+                limiter.Limit();
                 ws.Send(data);
             }
         }

--- a/MMBot.Slack/packages.config
+++ b/MMBot.Slack/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Bert.RateLimiters" version="1.0.0" targetFramework="net45" />
   <package id="Common.Logging" version="2.1.2" targetFramework="net45" />
   <package id="Microsoft.Owin" version="2.0.2" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />


### PR DESCRIPTION
Slack has [rate limits](https://api.slack.com/docs/rate-limits). This introduces a rate limiter to make sure the bot will not break them when too many sends are done in rapid succession. 
