### PR TITLE
Parse messages according to Slack Message format.

### DIFF
--- a/MMBot.Slack/SlackAdapter.cs
+++ b/MMBot.Slack/SlackAdapter.cs
@@ -28,6 +28,8 @@ namespace MMBot.Slack
         private bool _reconnect = true;
         private string[] _commandTokens;
         private string[] _logRooms;
+        private static readonly Regex regex = new Regex(@"<(?<type>[@#!])?(?<link>[^>|]+)(?:\|(?<label>[^>]+))?>");
+
 
         public SlackAdapter(ILog logger, string adapterId)
             : base(logger, adapterId)
@@ -228,7 +230,6 @@ namespace MMBot.Slack
         /// <returns>Text with formatting removed.</returns>
         private string RemoveFormatting(string text)
         {
-            Regex regex = new Regex(@"<(?<type>[@#!])?(?<link>[^>|]+)(?:\|(?<label>[^>]+))?>");
 
             text = regex.Replace(text, m =>
             {


### PR DESCRIPTION
This is my attempt to fix #204 . 

The slack message format is at https://api.slack.com/docs/formatting. When messages arrive the new RemoveFormatting method attempts to 'straighten' out the message so we just get the original message text. I used https://github.com/slackhq/hubot-slack/blob/master/src/slack.coffee#L153-192 as a guide.

_Note: This is my first pull request for a public repo. Any and all feedback is most welcome._
