### PR TITLE
Fix Robot.Hear Regex

### DIFF
--- a/MMBot.Core/Robot.cs
+++ b/MMBot.Core/Robot.cs
@@ -504,7 +504,7 @@ namespace MMBot
 
         private string PrepareHearRegexPattern(string regex)
         {
-            return string.Format("^(?:{0})", regex);
+            return string.Format("(?:{0})", regex);
         }
 
         private string PrepareRespondRegexPattern(string regex)


### PR DESCRIPTION
`Robot.Hear` is supposed to catch a pattern *anywhere* in a message, but its Regex preparation method (`PrepareHearRegexPattern`) was prefixing it with a `^`, so it only matched the specified pattern at the *start* of a message.

Before this fix, only the second of the following three examples from https://github.com/mmbot/mmbot/wiki/Writing-scripts actually worked:

* Stop badgering the witness
* badger me
* what exactly is a badger anyways

After this fix, all three of them work as expected.